### PR TITLE
prefix search: Add more stop words.

### DIFF
--- a/scripts/load-from-csv.py
+++ b/scripts/load-from-csv.py
@@ -7,7 +7,15 @@ from reddit_donate import models
 
 
 MIN_PREFIX_LEN = 3
-STOP_WORDS = ["the "]
+
+# words that would frequently get dropped in conversation about a charity but
+# show up in lots of them (e.g. "American Red Cross")
+STOP_WORDS = [
+    "american ",
+    "international ",
+    "national ",
+    "the ",
+]
 
 
 def _generate_prefixes(display_name):


### PR DESCRIPTION
I checked the data for the most common first words and then added the
ones that aren't integral to the names of the charities involved.  For
example, "united" was very common, but searching for "Way" and getting
"United Way" would be pretty strange.

:eyeglasses: @bsimpson63 @madbook 
