### PR TITLE
Remove extra ajax call on page load.

### DIFF
--- a/reddit_donate/controllers.py
+++ b/reddit_donate/controllers.py
@@ -55,7 +55,7 @@ class DonateController(RedditController):
         else:
             nomination_count = None
 
-        if (organization):
+        if organization:
             wrapped_organization = inject_nomination_status([organization])
         else:
             wrapped_organization = None

--- a/reddit_donate/controllers.py
+++ b/reddit_donate/controllers.py
@@ -47,12 +47,18 @@ def inject_nomination_status(organizations, assume_nominated=False):
 class DonateController(RedditController):
     @validate(
         eligible=VAccountEligible(),
+        organization=VOrganization("organization"),
     )
-    def GET_landing(self, eligible):
+    def GET_landing(self, eligible, organization):
         if c.user_is_loggedin:
             nomination_count = DonationNominationsByAccount.count(c.user)
         else:
             nomination_count = None
+
+        if (organization):
+            wrapped_organization = inject_nomination_status([organization])
+        else:
+            wrapped_organization = None
 
         content = pages.DonateLanding(
             eligible=eligible,
@@ -64,6 +70,7 @@ class DonateController(RedditController):
             extra_js_config={
                 "unloadedNominations": nomination_count,
                 "accountIsEligible": eligible,
+                "organization": wrapped_organization,
             },
         ).render()
 

--- a/reddit_donate/public/static/js/donate-stores.js
+++ b/reddit_donate/public/static/js/donate-stores.js
@@ -1,12 +1,16 @@
 !function(r, Flux, _) {
   'use strict';
 
+  var initialCharityData = r.config.organization;
+
   var searchResults = new Flux.Store({
     getDefaultState: function() {
+      var results = initialCharityData || [];
+
       return {
         query: '',
         queryType: 'name',
-        list: [],
+        list: results,
       };
     },
 
@@ -96,9 +100,17 @@
   });
 
   var charityData = new Flux.Store({
-    getInitialState: function() {
+    getDefaultState: function() {
+      var data;
+
+      if (initialCharityData && initialCharityData.length) {
+        data = this.getCharityDataByEin(initialCharityData);
+      } else {
+        data = {};
+      }
+
       return {
-        byEIN: {},
+        byEIN: data,
       };
     },
 
@@ -107,7 +119,7 @@
       var cache = {};
 
       sources.forEach(function(source) {
-        source.state.list.reduce(function(cache, data) {
+        source.reduce(function(cache, data) {
           cache[data.EIN] = data;
           return cache;
         }, cache);
@@ -121,7 +133,10 @@
         case 'update-nominated':
         case 'update-search-results':
           this.setState({
-            byEIN: this.getCharityDataByEin(searchResults, nominated),
+            byEIN: this.getCharityDataByEin(
+              searchResults.state.list,
+              nominated.state.list
+            ),
           });
         break;
       }

--- a/reddit_donate/public/static/js/donate-views.js
+++ b/reddit_donate/public/static/js/donate-views.js
@@ -138,7 +138,7 @@
       if (!LOGGED_IN) {
         button = A({
             className: classes,
-            href: DOMAIN + '/donate?ein=' + encodeURIComponent(this.props.EIN),
+            href: DOMAIN + '/donate?organization=' + encodeURIComponent(this.props.EIN),
           },
           r._('Log In to Nominate')
         );
@@ -361,12 +361,6 @@
           searchQuery: this.props.searchQuery || '',
           searchQueryType: 'name',
         };
-      },
-
-      componentWillMount: function() {
-        if (this.props.searchQuery) {
-          this.search(this.props.searchQuery, true);
-        }
       },
 
       handleKeyDown: function(e) {

--- a/reddit_donate/public/static/js/donate.js
+++ b/reddit_donate/public/static/js/donate.js
@@ -18,9 +18,7 @@
   var params = r.donate.getQueryParams();
   $(function() {
     React.renderComponent(
-      views.RedditDonateSearch({
-        searchQuery: params.ein || '',
-      }),
+      views.RedditDonateSearch(),
       document.getElementById('reddit-donate-search')
     );
 

--- a/reddit_donate/validators.py
+++ b/reddit_donate/validators.py
@@ -15,7 +15,7 @@ class VOrganization(VInt):
         try:
             ein = int(ein_text)
             return DonationOrganization.byEIN(ein)
-        except (ValueError, tdb_cassandra.NotFound):
+        except (TypeError, ValueError, tdb_cassandra.NotFound):
             self.set_error(errors.DONATE_UNKNOWN_ORGANIZATION)
             return None
 


### PR DESCRIPTION
If a user tries to vote while logged out, they are redirected to the search form with the EIN pre-filled, which triggers an ajax call to look up the charity. Instead, include the charity data as a config value in the initial page load so we can render without an extra request.

This also makes it a nicer experience if people want to share a direct link to a charity to vote on, as it removes the jarring pop-in effect.

:eyeglasses: @spladug 
