### PR TITLE
Boost ratelimit to one vote per second.

### DIFF
--- a/reddit_donate/controllers.py
+++ b/reddit_donate/controllers.py
@@ -24,7 +24,7 @@ from reddit_donate.models import (
 )
 
 
-NOMINATION_COOLDOWN = 15  # seconds
+NOMINATION_COOLDOWN = 1  # seconds
 
 
 def inject_nomination_status(organizations, assume_nominated=False):


### PR DESCRIPTION
Testing showed that voting/unvoting/then revoting would trigger the
ratelimit pretty handily.

:eyeglasses: @umbrae 
