### PR TITLE
Improve autocomplete indexing.

### DIFF
--- a/reddit_donate/models.py
+++ b/reddit_donate/models.py
@@ -6,6 +6,8 @@ from pycassa.cassandra.ttypes import NotFoundException
 from r2.lib import utils
 from r2.lib.db import tdb_cassandra
 
+from reddit_donate import utils as donate_utils
+
 
 MAX_COLUMNS = 150
 
@@ -107,7 +109,9 @@ class DonationOrganizationsByPrefix(tdb_cassandra.View):
 
     @classmethod
     def byPrefix(cls, prefix):
-        stripped = prefix.strip()
+        stripped = donate_utils.normalize_query(prefix)
+        if not stripped:
+            return []
         try:
             results = cls._cf.get(stripped, column_count=MAX_COLUMNS)
         except NotFoundException:

--- a/reddit_donate/utils.py
+++ b/reddit_donate/utils.py
@@ -1,0 +1,15 @@
+import sys
+import unicodedata
+
+
+SANITIZATION_MAPPING = dict.fromkeys(
+    i for i in xrange(sys.maxunicode)
+    if unicodedata.category(unichr(i)).startswith('P'))
+
+
+def sanitize_query(name):
+    return name.translate(SANITIZATION_MAPPING).lower().strip()
+
+
+def normalize_query(name):
+    return "".join(sanitize_query(name).split())

--- a/scripts/load-from-csv.py
+++ b/scripts/load-from-csv.py
@@ -3,32 +3,20 @@ from __future__ import print_function, division
 import csv
 import json
 
-from reddit_donate import models
+from reddit_donate import models, utils
 
 
 MIN_PREFIX_LEN = 3
 
-# words that would frequently get dropped in conversation about a charity but
-# show up in lots of them (e.g. "American Red Cross")
-STOP_WORDS = [
-    "american ",
-    "international ",
-    "national ",
-    "the ",
-]
-
 
 def _generate_prefixes(display_name):
-    sanitized = display_name.lower().strip()
+    sanitized = utils.sanitize_query(display_name)
 
-    for prefix_len in xrange(MIN_PREFIX_LEN, len(sanitized)+1):
-        yield sanitized[:prefix_len]
-
-    for stop_word in STOP_WORDS:
-        if sanitized.startswith(stop_word):
-            unstopped = sanitized[len(stop_word):].strip()
-            for prefix_len in xrange(MIN_PREFIX_LEN, len(unstopped)+1):
-                yield unstopped[:prefix_len]
+    words = sanitized.split()
+    for i in xrange(len(words)):
+        spaceless = "".join(words[i:])
+        for prefix_len in xrange(MIN_PREFIX_LEN, len(spaceless)+1):
+            yield spaceless[:prefix_len]
 
 
 def _coerce_values(mapping, function, keys):


### PR DESCRIPTION
This makes some improvements to the autocomplete:
- remove all punctuation and whitespace from consideration
  e.g. "charity: water" is matched by "charity water"
  and "donorschoose" by "donors choose"
- allow prefix matching to start at words other than the first
  e.g. "frontier" can match "electronic frontier foundation".

:eyeglasses: @madbook @bsimpson63 
