### PR TITLE
Shut it down

### DIFF
--- a/reddit_donate/__init__.py
+++ b/reddit_donate/__init__.py
@@ -61,7 +61,7 @@ class Donate(Plugin):
         mc(
             "/donate",
             controller="donate",
-            action="landing",
+            action="closed",
             conditions={"function": not_in_sr},
         )
 

--- a/reddit_donate/controllers.py
+++ b/reddit_donate/controllers.py
@@ -1,6 +1,7 @@
 from pylons import c, g
 from pylons.i18n import _
 
+from r2.config import feature
 from r2.controllers import add_controller
 from r2.controllers.reddit_base import RedditController
 from r2.lib.errors import errors
@@ -51,6 +52,9 @@ class DonateController(RedditController):
         organization=VOrganization("organization"),
     )
     def GET_landing(self, eligible, organization):
+        if not feature.is_enabled('reddit_donate'):
+            return self.abort404()
+
         if c.user_is_loggedin:
             nomination_count = DonationNominationsByAccount.count(c.user)
         else:
@@ -96,6 +100,9 @@ class DonateController(RedditController):
         organization=VOrganization("organization"),
     )
     def POST_nominate(self, form, jquery, organization):
+        if not feature.is_enabled('reddit_donate'):
+            return self.abort404()
+
         if form.has_errors("organization", errors.DONATE_UNKNOWN_ORGANIZATION):
             return
 
@@ -122,6 +129,9 @@ class DonateController(RedditController):
         organization=VOrganization("organization"),
     )
     def POST_unnominate(self, form, jquery, organization):
+        if not feature.is_enabled('reddit_donate'):
+            return self.abort404()
+
         if form.has_errors("organization", errors.DONATE_UNKNOWN_ORGANIZATION):
             return
 
@@ -136,6 +146,9 @@ class DonateController(RedditController):
     def GET_organization(self, responder, organization):
         """Look up a single org by EIN."""
 
+        if not feature.is_enabled('reddit_donate'):
+            return self.abort404()
+
         if responder.has_errors("organization",
                                 errors.DONATE_UNKNOWN_ORGANIZATION):
             return
@@ -149,6 +162,9 @@ class DonateController(RedditController):
     def GET_search(self, responder, prefix):
         """Get organizations by display-name prefix."""
 
+        if not feature.is_enabled('reddit_donate'):
+            return self.abort404()
+
         if responder.has_errors("prefix", errors.TOO_LONG, errors.TOO_SHORT):
             return
 
@@ -159,6 +175,8 @@ class DonateController(RedditController):
         VUser(),
     )
     def GET_nominations(self, responder):
+        if not feature.is_enabled('reddit_donate'):
+            return self.abort404()
         nominated_org_ids = DonationNominationsByAccount.get_for(c.user)
         orgs = DonationOrganization.byEIN(nominated_org_ids)
         wrapped = inject_nomination_status(orgs, assume_nominated=True)

--- a/reddit_donate/controllers.py
+++ b/reddit_donate/controllers.py
@@ -47,6 +47,12 @@ def inject_nomination_status(organizations, assume_nominated=False):
 
 @add_controller
 class DonateController(RedditController):
+    def GET_closed(self):
+        return pages.DonatePage(
+            title=_("reddit donate"),
+            content=pages.DonateClosed(),
+        ).render()
+
     @validate(
         eligible=VAccountEligible(),
         organization=VOrganization("organization"),

--- a/reddit_donate/pages.py
+++ b/reddit_donate/pages.py
@@ -21,3 +21,7 @@ class DonatePage(Reddit):
 
 class DonateLanding(Templated):
     pass
+
+
+class DonateClosed(Templated):
+    pass

--- a/reddit_donate/templates/donateclosed.html
+++ b/reddit_donate/templates/donateclosed.html
@@ -1,0 +1,17 @@
+<%!
+  from r2.lib.template_helpers import static
+%>
+
+<header class="reddit-donate-header md-container">
+  <div class="header-content md">
+    <h2>reddit donate</h2>
+    <div class="subtitle">giving 10% back</div>
+
+    <%
+    blog_post_url = "http://www.redditblog.com/2014/02/decimating-our-ads-revenue.html"
+    eligible_date_str = g.plugins['donate'].eligible_date_str
+    %>
+
+    <p>voting has ended! the winning charities will be announced within 48 hours.</p>
+  </div>
+</header>


### PR DESCRIPTION
Hides all of the endpoints back behind the feature flag (should still be set to employee only) and adds a simple page to state that voting is closed.
The text might change in a later push, currently looks like:

![screen shot 2015-02-25 at 10 49 18 am](https://cloud.githubusercontent.com/assets/2260961/6377879/3d1c7c82-bcdc-11e4-9a60-d2c959989a04.png)

:eyeglasses: @spladug 
